### PR TITLE
Update README files to add hands-on content and clarify prerequisites

### DIFF
--- a/01-custom-instructions/README.md
+++ b/01-custom-instructions/README.md
@@ -13,3 +13,7 @@
 - Visual Studio Code Insider (v1.99.0 +)
 - GitHub Copilot
 - Python 3.12 +
+
+## ハンズオン内容
+
+[手順書](HOL-step-by-step-guide-1.md)

--- a/02-refactor-existing-app/README.md
+++ b/02-refactor-existing-app/README.md
@@ -15,3 +15,7 @@
 - GitHub Copilot
 - Python 3.12 +
 - Node.js v22.14.0 +
+
+## ハンズオン内容
+
+[手順書](HOL-step-by-step-guide-1.md)


### PR DESCRIPTION
This pull request includes updates to the `README.md` files in the `01-custom-instructions` and `02-refactor-existing-app` directories. The changes add a new section for hands-on content with a link to a step-by-step guide.

Documentation updates:

* [`01-custom-instructions/README.md`](diffhunk://#diff-5db50c14aafa2155d7dafc495d15fd08a59a80909e56483295c384520d73aed9R16-R19): Added a "ハンズオン内容" section with a link to the step-by-step guide.
* [`02-refactor-existing-app/README.md`](diffhunk://#diff-d0d4e33a7e681c2cb24270fb2f314d37b72b7aac251cdb7723257f65e69afff0R18-R21): Added a "ハンズオン内容" section with a link to the step-by-step guide.